### PR TITLE
const char *service parameter

### DIFF
--- a/example/usage.cpp
+++ b/example/usage.cpp
@@ -25,6 +25,7 @@ int main(int argc, char **argv)
   }
 
   int port = std::stoi(argv[1]);
+  char *myport = argv[1];
 
   sockaddr_in svaddr;
   socklen_t len;
@@ -50,7 +51,7 @@ int main(int argc, char **argv)
 
   std::cout << "Port: " << port << "\n";
 
-  if (getaddrinfo(nullptr, (const char *) port, &hints, &result) != 0) {
+  if (getaddrinfo(nullptr, (const char *) myport, &hints, &result) != 0) {
     perror("getaddrinfo");
     return 1;
   }


### PR DESCRIPTION
If AI_NUMERICSERV is specified in hints.ai_flags and service is not NULL, then service must point to a string containing a numeric port number.This flag is used to inhibit the invocation of a name resolution service in cases where it is known not to be required.
Thus, char *myport parameter parsed as input to getaddrinfo.