### PR TITLE
Add TimerType support

### DIFF
--- a/example/usage.cpp
+++ b/example/usage.cpp
@@ -1,8 +1,8 @@
 // Copyright 2019 Victor Barbu
 
 #include <iostream>
-#include <microloop.h>
-#include <net/tcp_server.h>
+#include "microloop.h"
+#include "net/tcp_server.h"
 #include <string>
 #include <stdexcept>
 #include <limits>
@@ -44,6 +44,14 @@ int main(int argc, char **argv)
   auto tcp_server = microloop::net::TcpServer{static_cast<uint16_t>(port)};
   tcp_server.set_connection_callback(on_conn);
   tcp_server.set_data_callback(on_data);
+
+  microloop::timers::set_timeout(3000, []() {
+    std::cout << "Timer is done.\n";
+  });
+
+  microloop::timers::set_interval(2000, []() {
+    std::cout << "Interval is done.\n";
+  });
 
   while (true)
   {

--- a/example/usage.cpp
+++ b/example/usage.cpp
@@ -1,11 +1,12 @@
 // Copyright 2019 Victor Barbu
 
-#include <iostream>
 #include "microloop.h"
 #include "net/tcp_server.h"
-#include <string>
-#include <stdexcept>
+
+#include <iostream>
 #include <limits>
+#include <stdexcept>
+#include <string>
 
 using namespace microloop;
 
@@ -45,13 +46,9 @@ int main(int argc, char **argv)
   tcp_server.set_connection_callback(on_conn);
   tcp_server.set_data_callback(on_data);
 
-  microloop::timers::set_timeout(3000, []() {
-    std::cout << "Timer is done.\n";
-  });
+  microloop::timers::set_timeout(3000, []() { std::cout << "Timer is done.\n"; });
 
-  microloop::timers::set_interval(2000, []() {
-    std::cout << "Interval is done.\n";
-  });
+  microloop::timers::set_interval(2000, []() { std::cout << "Interval is done.\n"; });
 
   while (true)
   {

--- a/include/microloop.h
+++ b/include/microloop.h
@@ -4,19 +4,33 @@
 
 #pragma once
 
-#include <buffer.h>
-#include <event_loop.h>
-#include <event_sources/timeout.h>
+#include "buffer.h"
+#include "event_loop.h"
+#include "event_sources/timer.h"
+
 #include <string>
 
 namespace microloop::timers
 {
 
 template <typename Callback>
-static void set_timeout(int ms, Callback on_done)
+static void set_timeout(int ms, Callback on_expired)
 {
-  microloop::EventLoop::get_main()->add_event_source(
-      new microloop::event_sources::Timeout(ms, on_done));
+  using microloop::EventLoop;
+  using microloop::event_sources::Timer;
+  using microloop::event_sources::TimerType;
+
+  EventLoop::get_main()->add_event_source(new Timer(ms, TimerType::TIMEOUT, on_expired));
+}
+
+template <typename Callback>
+static void set_interval(int ms, Callback on_expired)
+{
+  using microloop::EventLoop;
+  using microloop::event_sources::Timer;
+  using microloop::event_sources::TimerType;
+
+  EventLoop::get_main()->add_event_source(new Timer(ms, TimerType::INTERVAL, on_expired));
 }
 
 }  // namespace microloop::timers


### PR DESCRIPTION
The `Timeout` class has been renamed to `Timer` and now supports a `TimerType` parameter. Utility functions have also been created/updated in `microloop.h`:

```cpp
template <typename Callback>
static void set_timeout(int ms, Callback on_expire);

template <typename Callback>
static void set_interval(int ms, Callback on_expire);
```