### PR TITLE
Use std::chrono::nanoseconds for Timer construction

### DIFF
--- a/example/usage.cpp
+++ b/example/usage.cpp
@@ -50,10 +50,8 @@ int main(int argc, char **argv)
 
   using microloop::event_sources::TimerController;
 
-  microloop::timers::set_timeout(
-      2000, event_loop, [](TimerController &) { std::cout << "Timer is done.\n"; });
-
-  microloop::timers::set_interval(600, event_loop, [](TimerController &timer) {
+  using namespace std::literals::chrono_literals;
+  microloop::timers::set_interval(6s, event_loop, [](TimerController &timer) {
     std::cout << "Interval is done.\n";
     std::cout << "Timer expired this many times: " << timer.get_expirations_count() << "\n";
 

--- a/include/microloop.h
+++ b/include/microloop.h
@@ -13,22 +13,21 @@ namespace microloop::timers
 {
 
 template <typename Callback>
-static void set_timeout(int ms, microloop::EventLoop *event_loop, Callback on_expired)
+static void set_timeout(std::chrono::nanoseconds val, EventLoop *event_loop, Callback cb)
 {
   using microloop::event_sources::Timer;
   using microloop::event_sources::TimerType;
 
-  event_loop->add_event_source(new Timer<Callback>(ms, TimerType::TIMEOUT, event_loop, on_expired));
+  event_loop->add_event_source(new Timer<Callback>(val, TimerType::TIMEOUT, event_loop, cb));
 }
 
 template <typename Callback>
-static void set_interval(int ms, microloop::EventLoop *event_loop, Callback on_expired)
+static void set_interval(std::chrono::nanoseconds val, EventLoop *event_loop, Callback cb)
 {
   using microloop::event_sources::Timer;
   using microloop::event_sources::TimerType;
 
-  event_loop->add_event_source(
-      new Timer<Callback>(ms, TimerType::INTERVAL, event_loop, on_expired));
+  event_loop->add_event_source(new Timer<Callback>(val, TimerType::INTERVAL, event_loop, cb));
 }
 
 }  // namespace microloop::timers


### PR DESCRIPTION
The constructor of `Timer` now takes `std::chrono::nanoseconds` as parameter. 

This choice instead of the more general `std::chrono::duration<Rep, Period>` comes from the fac the nanosecond is the smallest unit supported by the `timespec` structure.

A timer can now be constructed as follows:

```cpp
/* using duration specializations */
set_timeout(std::chrono::seconds{2}, /* ... */);

/* or using literals */
using namespace std::literals::chrono_literals;
set_interval(2s, /* ... */);
```

---
This pull request fixes #16.